### PR TITLE
Removed wildcard from input folder

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function ElixirScriptPlugin(config) {
     throw new Error("'outputFolder' required");
   }
 
-  this.config.inputFolder = this.stripTrailingSlash(this.config.inputFolder) + "/**/*.ex*";
+  this.config.inputFolder = this.stripTrailingSlash(this.config.inputFolder);
   this.config.outputFolder = this.stripTrailingSlash(this.config.outputFolder);
 
   this.compile = this.debounce((params, callback) => { this.doCompile(params, callback) }, 250);


### PR DESCRIPTION
In the latest version of elixirscript (0.18.0), only the path is needed to be passed in and the compiler will find the relevant file extensions
